### PR TITLE
Removed prompt when installing dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,4 @@ install: packages
 	cp plot_* /usr/bin
 	cp fairness.sh /usr/bin
 packages:
-	apt-get install iperf3
-	apt-get install jq
-	apt-get	install gnuplot
-
+	apt-get -y install iperf3 jq gnuplot


### PR DESCRIPTION
Hello. First of all thank you for the tool, I use it quite often!

I modified the makefile in such a way that users won't have to type down yes when installing the dependencies.
This simple fix will prevent potential scripts from hanging. I am myself automatically installing your tool on VMs using a script.
