### PR TITLE
Enhancing Error Handling, errors will not interrupt the execution of subsequent files

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ This script accepts iPerf3's JSON file, calls preprocessor, and calls gnuplot to
 - pmtu
 - omitted
 
+## Updates
+The plot_iperf.sh script has been improved for better error handling and modularity:
+1. The script now processes each gnuplot .plt file individually.
+2. Errors encountered while executing a .plt file are logged to an error.out file in the current directory, without interrupting the execution of subsequent files.
+
 ## Install
 This script requires jq and gnuplot.
 Run the following command in the script's directory. It installs the dependencies, and makes the scripts accessible anywhere.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ This script accepts iPerf3's JSON file, calls preprocessor, and calls gnuplot to
 ## Updates
 The plot_iperf.sh script has been improved for better error handling and modularity:
 1. The script now processes each gnuplot .plt file individually.
-2. Errors encountered while executing a .plt file are logged to an error.out file in the current directory, without interrupting the execution of subsequent files.
+2. Execution success or failure for each .plt file is now explicitly logged:
+- **Success:** Prints a message indicating the file was executed successfully.
+- **Error:** Prints an error message and logs errors encountered while executing a .plt file to an error.out file in the current directory, without interrupting the execution of subsequent files.
 
 ## Install
 This script requires jq and gnuplot.

--- a/plot_iperf.sh
+++ b/plot_iperf.sh
@@ -14,5 +14,9 @@ if [ $? -ne 0 ]; then
 fi
 
 cd results
-gnuplot /usr/bin/*.plt 2> /dev/null
+
+for plt in /usr/bin/*.plt; do
+    echo "Executing $plt..."
+    gnuplot "$plt" 2>> ../error.out || echo "Error in $plt" >> ../error.out
+done
 

--- a/plot_iperf.sh
+++ b/plot_iperf.sh
@@ -17,6 +17,6 @@ cd results
 
 for plt in /usr/bin/*.plt; do
     echo "Executing $plt..."
-    gnuplot "$plt" 2>> ../error.out || echo "Error in $plt" >> ../error.out
+    gnuplot "$plt" 2>> ../error.out || echo "Error in $plt"
 done
 


### PR DESCRIPTION
Updates
The plot_iperf.sh script has been improved for better error handling and modularity:
The script now processes each Gnuplot .plt file individually.
Execution success or failure for each .plt file is now explicitly logged:
Success: Prints a message indicating the file was executed successfully.
Error: Prints an error message and logs errors encountered while executing a .plt file to an error.out file in the current directory, without interrupting the execution of subsequent files.